### PR TITLE
Better settings for next year

### DIFF
--- a/processing.jl
+++ b/processing.jl
@@ -29,6 +29,7 @@ args = ```
 -c:v libx264
 -preset slow
 -crf 18
+-ar 48000
 -c:a aac
 -b:a 192k
 -movflags +faststart

--- a/processing.jl
+++ b/processing.jl
@@ -7,22 +7,22 @@ const file = ARGS[2]
 
 # 1. Query properties of file
 
-json = join(FFMPEG.exe(`-v error -show_entries stream=width,height -of json $(file)`, command=FFMPEG.ffprobe, collect=true), "\n")
+json = join(FFMPEG.exe(`-v error -show_entries stream=width,height,r_frame_rate -of json $(file)`, command=FFMPEG.ffprobe, collect=true), "\n")
 properties = JSON.Parser.parse(json)
 streams = properties["streams"]
 
-filter!(!isempty, streams)
-sizes = map(stream -> (stream["width"], stream["height"]), streams)
+filter!(i -> !isempty(i) && get(i, "r_frame_rate", "0/0") != "0/0", streams)
+metadata = map(stream -> (stream["width"], stream["height"], stream["r_frame_rate"]), streams)
 
-unique!(sizes)
-width, height = only(sizes)
+unique!(metadata)
+width, height, fps = only(metadata)
 
 args = ```
 -i $(preroll)
 -i $(file)
 -filter_complex 
-"[0:v]scale=$(width):$(height):force_original_aspect_ratio=decrease,pad=$(width):$(height):-1:-1,setsar=1,fps=30,format=yuv420p[v0]; \
- [1:v]setsar=1,fps=30,format=yuv420p[v1];
+"[0:v]scale=$(width):$(height):force_original_aspect_ratio=decrease,pad=$(width):$(height):-1:-1,setsar=1,fps=$fps,format=yuv420p[v0]; \
+ [1:v]setsar=1,fps=$fps,format=yuv420p[v1];
   [v0][0:a][v1][1:a]concat=n=2:v=1:a=1[v][a]"
 -map "[v]"
 -map "[a]"


### PR DESCRIPTION
This makes two changes:

First, it respects the frame rate of the input file. There is in general no good way to convert footage that was shot in one framerate into a different one. The problem is worse for some transitions than others, for example 29.97 -> 30 is not a big problem, but 24 -> 30 will result in a choppy video. The first commit here just extracts the frame rate in the source footage and uses that for the output video. If you want to be perfectionists, you could also render the preroll video in a really high frame rate (at the moment it is in 29.97) so that it always converts nicely to the output fps (very high fps to lower fps also works well).

Second, it sets the output audio to 48 kHz. All video stuff always uses 48 kHz, but the current configuration produces videos with 44 kHz. I think the reason is that the preroll video uses 44 kHz and then that is presumably just used for the entire video.

Everything at best lightly tested, so definitely only for next year :)